### PR TITLE
Fix the includes to prevent the make process from looping

### DIFF
--- a/src/swif_linear-code.c
+++ b/src/swif_linear-code.c
@@ -35,8 +35,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "general.h"
-#include "linear-code.h"
+#include "swif_general.h"
+#include "swif_linear-code.h"
 
 /*--------------------------------------------------*/
 
@@ -57,7 +57,7 @@
 
 #ifdef WITH_GF256_MUL_TABLE
 
-#include "table-mul-gf256.c"
+#include "swif_table-mul-gf256.c"
 static inline uint8_t gf256_mul(uint8_t a, uint8_t b)
 { return gf256_mul_table[a][b]; }
 


### PR DESCRIPTION
Hello,

Here is a humble contribution that is only intended to avoid the `make` process from entering in an infinite loop.

What I noticed is that the compiler cannot fetch the dependencies of some source files due to wrong file names in some `#include` directives. This results in the `make` process to be re-executed and enter in an infinite execution loop.

The result of this this fix is that there are still compilation errors but the `make` is now able to go one step further and fetch the correct header files which prevents it from looping infinitely.