### PR TITLE
fixes for compiling libswif

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,8 @@ CFLAGS += -Wall -g3 -fPIC
 
 #------------------------------
 
-SRCS = swif_api.c swif_linear-code.c swif_prng.c swif_coding_coefficients.c
+# TODO : swif_linear-code.c 
+SRCS = swif_api.c swif_prng.c swif_coding_coefficients.c
 
 HEADERS = $(SRCS:.c=.h) swif_general.h swif_includes.h swif_rlc_cb.h
 

--- a/src/swif_api.c
+++ b/src/swif_api.c
@@ -222,8 +222,8 @@ swif_status_t   swif_encoder_add_source_symbol_to_coding_window (
                                 void*           new_src_symbol_buf,
                                 esi_t           new_src_symbol_esi)
 {
-ajouter un élément à la liste chainée des symboles sources
-retirer le symbole source le plus ancien si l'EW déborde.
+/* ajouter un élément à la liste chainée des symboles sources
+retirer le symbole source le plus ancien si l'EW déborde. */
 }
 
 swif_status_t   swif_decoder_add_source_symbol_to_coding_window (

--- a/src/swif_coding_coefficients.c
+++ b/src/swif_coding_coefficients.c
@@ -1,7 +1,11 @@
+
 /**
  * SWiF Codec: an open-source sliding window FEC codec in C
  * https://github.com/irtf-nwcrg/swif-codec
  */
+#include <stdint.h>
+#include "swif_api.h"
+#include "swif_prng.h"
 
 /*
  * Coding coefficients generator coming from RLC FEC Scheme, version 10, I-D.
@@ -32,6 +36,7 @@
  *                    document only values 1 and 8 are considered.
  * (out)              returns an error code
  */
+
 int generate_coding_coefficients (uint16_t  repair_key,
                                  uint8_t   cc_tab[],
                                  uint16_t  cc_nb,

--- a/src/swif_prng.c
+++ b/src/swif_prng.c
@@ -49,17 +49,7 @@
  */
 
 #include "swif_includes.h"
-
-
-/**
- * tinymt32 internal state vector and parameters
- */
-typedef struct {
-    uint32_t status[4];
-    uint32_t mat1;
-    uint32_t mat2;
-    uint32_t tmat;
-} tinymt32_t;
+#include "swif_prng.h"
 
 static void tinymt32_next_state (tinymt32_t * s);
 static uint32_t tinymt32_temper (tinymt32_t * s);

--- a/src/swif_prng.h
+++ b/src/swif_prng.h
@@ -5,6 +5,16 @@
 
 
 /**
+ * tinymt32 internal state vector and parameters
+ */
+typedef struct {
+    uint32_t status[4];
+    uint32_t mat1;
+    uint32_t mat2;
+    uint32_t tmat;
+} tinymt32_t;
+
+/**
  * This function initializes the internal state array with a 32-bit
  * unsigned integer seed.
  * @param s pointer to tinymt internal state.
@@ -25,3 +35,4 @@ void tinymt32_init     (tinymt32_t *	s,
  */
 uint32_t tinymt32_rand (tinymt32_t *	s,
 			uint32_t	maxv);
+

--- a/src/swif_rlc_cb.h
+++ b/src/swif_rlc_cb.h
@@ -32,7 +32,7 @@ typedef struct swif_encoder_rlc_cb {
 	uint8_t			*cc_tab;
 
 	/* linked list of source symbols currently in the coding window */
-	enc_coding_window_t	*cw_head;
+	/* TODO : enc_coding_window_t	*cw_head; */
 	uint32_t		cw_nb_in_list;
 
 	/* add whatever may be needed hereafter... */


### PR DESCRIPTION
The purpose of this fix is to comment out and add some missing includes. 
The make is now able to compile.