### PR TITLE
renaming errno to swif_errno

### DIFF
--- a/src/swif_rlc_cb.h
+++ b/src/swif_rlc_cb.h
@@ -16,7 +16,7 @@ typedef struct swif_encoder_rlc_cb {
 
 	/* when a function returns with SWIF_STATUS_ERROR, the errno
 	 * variable contains a more detailed error type. */
-	swif_errno_t		errno;
+	swif_errno_t		swif_errno;
 
 	/* desired verbosity: 0 is the minimum verbosity, the maximum
 	 * level being implementation specific. */
@@ -51,7 +51,7 @@ typedef struct swif_decoder_rlc_cb {
 
 	/* when a function returns with SWIF_STATUS_ERROR, the errno
 	 * variable contains a more detailed error type. */
-	swif_errno_t		errno;
+	swif_errno_t		swif_errno;
 
 	/* desired verbosity: 0 is the minimum verbosity, the maximum
 	 * level being implementation specific. */


### PR DESCRIPTION
Renaming `errno` to `swif_errno` for `struct swif_encoder_rlc_cb` and `struct swif_decoder_rlc_cb`.

This avoids compilation problems due to the fact that `errno` is a macro. 
Note that C standard says:
>  If a macro definition is suppressed in order to access an actual object, or a program defines an identifier with the name errno, the behavior is undefined.
